### PR TITLE
Feature/request fine tuning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,31 @@
+# Changelog
+
+## v2.1.0 (2017-12-22)
+
+- Expose internal Json decoders 
+- Enable users to adjust requests made to the Authorization Server to cope with possible 
+  implementation quirks (like GitHub API v3)
+
+## v2.0.3 (2017-06-04)
+
+- Update LICENSE's information
+- Fix broken links and examples in README
+
+## v2.0.2 (2017-06-02)
+
+- Fix bug about empty scope parameter being sent when `Nothing` is provided as a scope
+
+
+## v2.0.1 (2017-06-02)
+
+- Enhance documentation about response parameters
+
+## v2.0.0 (2017-06-02)
+
+- Review type `Response` to provide a clearer API
+- Fix typos and references in examples
+
+
+## v1.0.0 (2017-06-01)
+
+- Initial release, support for all 4 grant types.

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ in
 
 ### TroubleShooting
 
-##### Interating with GitHub
+##### Interacting with GitHub
 
 GitHub API v3 supports the [Authorization Code Flow](https://developer.github.com/apps/building-oauth-apps/authorization-options-for-oauth-apps/#web-application-flow) 
 in order to obtain access tokens for a registered application. However, the implementation 
@@ -268,3 +268,8 @@ getToken code =
     in
         Http.send handleResponse req
 ```
+
+## Changelog
+
+[CHANGELOG.md](./CHANGELOG.md)
+

--- a/README.md
+++ b/README.md
@@ -204,3 +204,67 @@ let
 in
     { model | token = Just token } ! [ Http.send handleResponse req ]
 ```
+
+### TroubleShooting
+
+##### Interating with GitHub
+
+GitHub API v3 supports the [Authorization Code Flow](https://developer.github.com/apps/building-oauth-apps/authorization-options-for-oauth-apps/#web-application-flow) 
+in order to obtain access tokens for a registered application. However, the implementation 
+presents a flaw which makes it not compliant with the official RFC:
+
+- By default, GitHub's authorization server will respond with a `x-www-form-urlencoded` mime-type
+  when trying to exchange the authorization code against an access token (instead of a
+  `application/json` mime-type as specified in the official RFC).
+
+- This behavior can be changed by providing an extra `Accept: application/json` header with the
+  authenticate request. However, by doing so, GitHub's authorization server will encode the 
+  `scope` of the response as a comma-separated list (instead of a space-separated list as
+  specified in the official RFC).
+
+Hence, this library provides a way to work around this implementation quirks by adjusting the 
+authentication request before it gets sent. To achieve this, one may use the various decoders
+now exposed in [OAuth.Decode](http://package.elm-lang.org/packages/truqu/elm-oauth2/latest/OAuth-Decode) 
+to craft a custom transformation function for the `authenticateWithOpts` functions.
+
+Here's a small example of how to work around GitHub's API v3 implementation:
+
+```elm
+lenientResponseDecoder : Json.Decoder ResponseToken
+lenientResponseDecoder =
+    Json.map5 OAuth.Decode.makeResponseToken
+        OAuth.Decode.accessTokenDecoder
+        OAuth.Decode.expiresInDecoder
+        OAuth.Decode.refreshTokenDecoder
+        OAuth.Decode.lenientScopeDecoder
+        OAuth.Decode.stateDecoder
+
+
+adjustRequest : AdjustRequest ResponseToken
+adjustRequest req =
+    let
+        headers =
+            [ Http.header "Accept" ("application/json") ] :: req.headers
+
+        expect =
+            Http.expectJson lenientResponseDecoder
+    in
+        { req | headers = headers, expect = expect }
+
+
+getToken : String -> Cmd ResponseToken
+getToken code =
+    let
+        req =
+            OAuth.AuthorizationCode.authenticateWithOpts adjustRequest <|
+                OAuth.AuthorizationCode
+                    { credentials = { clientId = "clientId", secret = "secret" }
+                    , code = code
+                    , redirectUri = "redirectUri"
+                    , scope = [ "whatever" ]
+                    , state = Nothing
+                    , url = "tokenEndpoint"
+                    }
+    in
+        Http.send handleResponse req
+```

--- a/elm-package.json
+++ b/elm-package.json
@@ -13,7 +13,8 @@
         "OAuth.AuthorizationCode",
         "OAuth.Implicit",
         "OAuth.ClientCredentials",
-        "OAuth.Password"
+        "OAuth.Password",
+        "OAuth.Decode"
     ],
     "dependencies": {
         "Bogdanp/elm-querystring": "1.0.0 <= v < 2.0.0",

--- a/elm-package.json
+++ b/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.0.3",
+    "version": "2.1.0",
     "summary": "OAuth 2.0 client-side utils",
     "repository": "https://github.com/truqu/elm-oauth2.git",
     "license": "MIT",

--- a/src/OAuth/AuthorizationCode.elm
+++ b/src/OAuth/AuthorizationCode.elm
@@ -34,6 +34,7 @@ request.
 -}
 
 import OAuth exposing (..)
+import OAuth.Decode exposing (..)
 import Navigation as Navigation
 import Internal as Internal
 import QueryString as QS
@@ -58,7 +59,18 @@ In this case, use the `AuthorizationCode` constructor.
 -}
 authenticate : Authentication -> Http.Request ResponseToken
 authenticate =
-    Internal.authenticate
+    Internal.authenticate identity
+
+
+{-| Authenticate the client using the authorization code obtained from the authorization, passing
+additional custom options. Use with care.
+
+In this case, use the `AuthorizationCode` constructor.
+
+-}
+authenticateWithOpts : AdjustRequest ResponseToken -> Authentication -> Http.Request ResponseToken
+authenticateWithOpts fn =
+    Internal.authenticate fn
 
 
 {-| Parse the location looking for a parameters set by the resource provider server after

--- a/src/OAuth/ClientCredentials.elm
+++ b/src/OAuth/ClientCredentials.elm
@@ -24,6 +24,7 @@ request.
 -}
 
 import OAuth exposing (..)
+import OAuth.Decode exposing (..)
 import Internal as Internal
 import Http as Http
 
@@ -35,4 +36,15 @@ In this case, use the `ClientCredentials` constructor.
 -}
 authenticate : Authentication -> Http.Request ResponseToken
 authenticate =
-    Internal.authenticate
+    Internal.authenticate identity
+
+
+{-| Authenticate the client using the authorization code obtained from the authorization, passing
+additional custom options. Use with care.
+
+In this case, use the `ClientCredentials` constructor.
+
+-}
+authenticateWithOpts : AdjustRequest ResponseToken -> Authentication -> Http.Request ResponseToken
+authenticateWithOpts fn =
+    Internal.authenticate fn

--- a/src/OAuth/Decode.elm
+++ b/src/OAuth/Decode.elm
@@ -1,0 +1,170 @@
+module OAuth.Decode exposing (..)
+
+{-| This module exposes decoders and helpers to fine tune some requests when necessary.
+
+This might come in handy for provider that doesn't exactly implement the OAuth 2.0 RFC
+(like the API v3 of GitHub). With these utilities, one should hopefully be able to adjust
+requests made to the Authorization Server and cope with implementation quirks.
+
+
+## Type Utilities
+
+@docs RequestParts, AdjustRequest
+
+
+## Json Decoders
+
+@docs responseDecoder, expiresInDecoder, scopeDecoder, lenientScopeDecoder, stateDecoder, accessTokenDecoder, refreshTokenDecoder
+
+
+## Constructors
+
+@docs makeToken, makeResponseToken
+
+-}
+
+import OAuth exposing (..)
+import Json.Decode as Json
+import Http as Http
+import Time exposing (Time)
+
+
+{-| Parts required to build a request. This record is given to `Http.request` in order
+to create a new request and may be adjusted at will.
+-}
+type alias RequestParts a =
+    { method : String
+    , headers : List Http.Header
+    , url : String
+    , body : Http.Body
+    , expect : Http.Expect a
+    , timeout : Maybe Time
+    , withCredentials : Bool
+    }
+
+
+{-| Alias for the behavior passed to some function in order to adjust Http Request before they get
+sent
+
+For instance,
+
+    adjustRequest : AdjustRequest ResponseToken
+    adjustRequest req =
+        { req | headers = [ Http.header "Accept" ("application/json") ] :: req.headers }
+
+-}
+type alias AdjustRequest a =
+    RequestParts a -> RequestParts a
+
+
+{-| Json decoder for a response. You may provide a custom response decoder using other decoders
+from this module, or some of your own craft.
+
+For instance,
+
+    myScopeDecoder : Json.Decoder (Maybe (List String))
+    myScopeDecoder =
+        Json.maybe <|
+            Json.oneOf
+                [ Json.field "scope" (Json.map (String.split ",") Json.string) ]
+
+    myResponseDecoder : Json.Decoder ResponseToken
+    myResponseDecoder =
+        Json.map5 makeResponseToken
+            accessTokenDecoder
+            expiresInDecoder
+            refreshTokenDecoder
+            myScopeDecoder
+            stateDecoder
+
+-}
+responseDecoder : Json.Decoder ResponseToken
+responseDecoder =
+    Json.map5 makeResponseToken
+        accessTokenDecoder
+        expiresInDecoder
+        refreshTokenDecoder
+        scopeDecoder
+        stateDecoder
+
+
+{-| Json decoder for an expire timestamp
+-}
+expiresInDecoder : Json.Decoder (Maybe Int)
+expiresInDecoder =
+    Json.maybe <| Json.field "expires_in" Json.int
+
+
+{-| Json decoder for a scope
+-}
+scopeDecoder : Json.Decoder (Maybe (List String))
+scopeDecoder =
+    Json.maybe <| Json.field "scope" (Json.list Json.string)
+
+
+{-| Json decoder for a scope, allowing comma- or space-separated scopes
+-}
+lenientScopeDecoder : Json.Decoder (Maybe (List String))
+lenientScopeDecoder =
+    Json.maybe <|
+        Json.field "scope" <|
+            Json.oneOf
+                [ Json.list Json.string
+                , Json.map (String.split ",") Json.string
+                ]
+
+
+{-| Json decoder for a state
+-}
+stateDecoder : Json.Decoder (Maybe String)
+stateDecoder =
+    Json.maybe <| Json.field "state" Json.string
+
+
+{-| Json decoder for an access token
+-}
+accessTokenDecoder : Json.Decoder Token
+accessTokenDecoder =
+    let
+        mtoken =
+            Json.map2 makeToken
+                (Json.field "access_token" Json.string |> Json.map Just)
+                (Json.field "token_type" Json.string)
+
+        failUnless =
+            Maybe.map Json.succeed >> Maybe.withDefault (Json.fail "can't decode token")
+    in
+        Json.andThen failUnless mtoken
+
+
+{-| Json decoder for a refresh token
+-}
+refreshTokenDecoder : Json.Decoder (Maybe Token)
+refreshTokenDecoder =
+    Json.map2 makeToken
+        (Json.maybe <| Json.field "refresh_token" Json.string)
+        (Json.field "token_type" Json.string)
+
+
+{-| Create a ResponseToken record from various parameters
+-}
+makeResponseToken : Token -> Maybe Int -> Maybe Token -> Maybe (List String) -> Maybe String -> ResponseToken
+makeResponseToken token expiresIn refreshToken scope state =
+    { token = token
+    , expiresIn = expiresIn
+    , refreshToken = refreshToken
+    , scope = Maybe.withDefault [] scope
+    , state = state
+    }
+
+
+{-| Create a Token from a value and token type. Note that only bearer token are supported
+-}
+makeToken : Maybe String -> String -> Maybe Token
+makeToken mtoken tokenType =
+    case ( mtoken, String.toLower tokenType ) of
+        ( Just token, "bearer" ) ->
+            Just <| Bearer token
+
+        _ ->
+            Nothing

--- a/src/OAuth/Password.elm
+++ b/src/OAuth/Password.elm
@@ -25,6 +25,7 @@ request.
 -}
 
 import OAuth exposing (..)
+import OAuth.Decode exposing (..)
 import Internal as Internal
 import Http as Http
 
@@ -36,4 +37,15 @@ In this case, use the `Password` constructor.
 -}
 authenticate : Authentication -> Http.Request ResponseToken
 authenticate =
-    Internal.authenticate
+    Internal.authenticate identity
+
+
+{-| Authenticate the client using the authorization code obtained from the authorization, passing
+additional custom options. Use with care.
+
+In this case, use the `Password` constructor.
+
+-}
+authenticateWithOpts : AdjustRequest ResponseToken -> Authentication -> Http.Request ResponseToken
+authenticateWithOpts fn =
+    Internal.authenticate fn


### PR DESCRIPTION
This PR gives extra control over authenticate requests by exposing an extra `authenticateWithOpts` method to retrieve an access token. This methods grants the ability to fine-tune the request (and decoders) to retrieve an access token. 

This should help to cope with non-standard implementation like GitHub API V3 (see #3)

An example of usage could be:

```elm
lenientResponseDecoder : Json.Decoder ResponseToken
lenientResponseDecoder =
    Json.map5 OAuth.Decode.makeResponseToken
        OAuth.Decode.accessTokenDecoder
        OAuth.Decode.expiresInDecoder
        OAuth.Decode.refreshTokenDecoder
        OAuth.Decode.lenientScopeDecoder
        OAuth.Decode.stateDecoder


adjustRequest : AdjustRequest ResponseToken
adjustRequest req =
    let
        headers =
            [ Http.header "Accept" ("application/json") ] :: req.headers

        expect =
            Http.expectJson lenientResponseDecoder
    in
        { req | headers = headers, expect = expect }


getToken : String -> Cmd ResponseToken
getToken code =
    let
        req =
            OAuth.AuthorizationCode.authenticateWithOpts adjustRequest <|
                OAuth.AuthorizationCode
                    { credentials = { clientId = "clientId", secret = "secret" }
                    , code = code
                    , redirectUri = "redirectUri"
                    , scope = [ "whatever" ]
                    , state = Nothing
                    , url = "tokenEndpoint"
                    }
    in
        Http.send handleResponse req
```

**EDIT** Adjust the `expect` field in the `adjustRequest` function to also use the lenient decoder
