### PR TITLE
Support OpenID Connect tokens

### DIFF
--- a/src/Internal.elm
+++ b/src/Internal.elm
@@ -6,7 +6,6 @@ import Http as Http
 import QueryString as QS
 import Navigation as Navigation
 import Base64
-import Json.Decode as JsonD
 
 
 authorize : Authorization -> Cmd msg
@@ -165,7 +164,7 @@ parseIDToken idToken =
         [ part0, part1, signature ] ->
             case Base64.decode part1 of
                 Ok payload ->
-                    case JsonD.decodeString decodeJWTPayload payload of
+                    case decodeJWTPayloadString payload of
                         Ok token ->
                             Result.Ok { token | token = Bearer idToken }
 
@@ -205,10 +204,3 @@ qsAddMaybe param ms qs =
 
         Just s ->
             QS.add param s qs
-
-
-decodeJWTPayload : JsonD.Decoder ResponseToken
-decodeJWTPayload =
-    JsonD.maybe (JsonD.field "exp" JsonD.int)
-        |> JsonD.andThen
-            (\exp -> JsonD.succeed <| ResponseToken exp Nothing [] Nothing (Bearer ""))

--- a/src/Internal.elm
+++ b/src/Internal.elm
@@ -162,7 +162,7 @@ parseIDToken : String -> Result ParseErr ResponseToken
 parseIDToken idToken =
     case String.split "." idToken of
         [ part0, part1, signature ] ->
-            case Base64.decode part1 of
+            case base64Decode part1 of
                 Ok payload ->
                     case decodeJWTPayloadString payload of
                         Ok token ->
@@ -204,3 +204,17 @@ qsAddMaybe param ms qs =
 
         Just s ->
             QS.add param s qs
+
+
+base64Decode : String -> Result String String
+base64Decode data =
+    case Base64.decode data of
+        Ok payload ->
+            -- The payload may have an extra "\0" char due to base64 decode
+            if not (String.endsWith "}" payload) then
+                Ok <| String.dropRight 1 payload
+            else
+                Ok payload
+
+        Err err ->
+            Result.Err err

--- a/src/OAuth.elm
+++ b/src/OAuth.elm
@@ -192,6 +192,7 @@ authentication and directly retrieve a `Token` from the authorization.
 type ResponseType
     = Code
     | Token
+    | IDToken
 
 
 {-| The response obtained as a result of an authentication (implicit or not)
@@ -354,6 +355,9 @@ showResponseType r =
 
         Token ->
             "token"
+
+        IDToken ->
+            "id_token"
 
 
 {-| Gets the `String` representation of a `Token`.

--- a/src/OAuth.elm
+++ b/src/OAuth.elm
@@ -10,10 +10,8 @@ module OAuth
         , ResponseToken
         , ResponseCode
         , Token(..)
-        , decodeJWTPayloadString
         , errCodeFromString
         , errDecoder
-        , jwtPayloadDecoder
         , showErrCode
         , showResponseType
         , showToken
@@ -59,7 +57,7 @@ used.
 
 ## Responses
 
-@docs ResponseToken, ResponseCode, Token, Err, ParseErr, ErrCode, showToken, showErrCode, errCodeFromString, errDecoder, jwtPayloadDecoder, decodeJWTPayloadString
+@docs ResponseToken, ResponseCode, Token, Err, ParseErr, ErrCode, showToken, showErrCode, errCodeFromString, errDecoder
 
 -}
 
@@ -447,19 +445,3 @@ errDecoder =
         (Json.maybe <| Json.field "error_uri" Json.string)
         (Json.maybe <| Json.field "error_description" Json.string)
         (Json.maybe <| Json.field "state" Json.string)
-
-
-{-| A json decoder for JWT
--}
-jwtPayloadDecoder : Json.Decoder ResponseToken
-jwtPayloadDecoder =
-    Json.maybe (Json.field "exp" Json.int)
-        |> Json.andThen
-            (\exp -> Json.succeed <| ResponseToken exp Nothing [] Nothing (Bearer ""))
-
-
-{-| Parse a json JWT payload
--}
-decodeJWTPayloadString : String -> Result String ResponseToken
-decodeJWTPayloadString =
-    Json.decodeString jwtPayloadDecoder

--- a/src/OAuth.elm
+++ b/src/OAuth.elm
@@ -10,8 +10,10 @@ module OAuth
         , ResponseToken
         , ResponseCode
         , Token(..)
+        , decodeJWTPayloadString
         , errCodeFromString
         , errDecoder
+        , jwtPayloadDecoder
         , showErrCode
         , showResponseType
         , showToken
@@ -57,7 +59,7 @@ used.
 
 ## Responses
 
-@docs ResponseToken, ResponseCode, Token, Err, ParseErr, ErrCode, showToken, showErrCode, errCodeFromString, errDecoder
+@docs ResponseToken, ResponseCode, Token, Err, ParseErr, ErrCode, showToken, showErrCode, errCodeFromString, errDecoder, jwtPayloadDecoder, decodeJWTPayloadString
 
 -}
 
@@ -445,3 +447,19 @@ errDecoder =
         (Json.maybe <| Json.field "error_uri" Json.string)
         (Json.maybe <| Json.field "error_description" Json.string)
         (Json.maybe <| Json.field "state" Json.string)
+
+
+{-| A json decoder for JWT
+-}
+jwtPayloadDecoder : Json.Decoder ResponseToken
+jwtPayloadDecoder =
+    Json.maybe (Json.field "exp" Json.int)
+        |> Json.andThen
+            (\exp -> Json.succeed <| ResponseToken exp Nothing [] Nothing (Bearer ""))
+
+
+{-| Parse a json JWT payload
+-}
+decodeJWTPayloadString : String -> Result String ResponseToken
+decodeJWTPayloadString =
+    Json.decodeString jwtPayloadDecoder

--- a/src/OAuth/Decode.elm
+++ b/src/OAuth/Decode.elm
@@ -14,7 +14,7 @@ requests made to the Authorization Server and cope with implementation quirks.
 
 ## Json Decoders
 
-@docs responseDecoder, expiresInDecoder, scopeDecoder, lenientScopeDecoder, stateDecoder, accessTokenDecoder, refreshTokenDecoder
+@docs responseDecoder, expiresInDecoder, scopeDecoder, lenientScopeDecoder, stateDecoder, accessTokenDecoder, refreshTokenDecoder, jwtPayloadDecoder, decodeJWTPayloadString
 
 
 ## Constructors
@@ -168,3 +168,19 @@ makeToken mtoken tokenType =
 
         _ ->
             Nothing
+
+
+{-| A json decoder for JWT
+-}
+jwtPayloadDecoder : Json.Decoder ResponseToken
+jwtPayloadDecoder =
+    Json.maybe (Json.field "exp" Json.int)
+        |> Json.andThen
+            (\exp -> Json.succeed <| ResponseToken exp Nothing [] Nothing (Bearer ""))
+
+
+{-| Parse a json JWT payload
+-}
+decodeJWTPayloadString : String -> Result String ResponseToken
+decodeJWTPayloadString =
+    Json.decodeString jwtPayloadDecoder

--- a/src/OAuth/Implicit.elm
+++ b/src/OAuth/Implicit.elm
@@ -59,8 +59,8 @@ parse { hash } =
         geti =
             flip (QS.one QS.int) qs
     in
-        case ( gets "access_token", gets "error" ) of
-            ( Just accessToken, _ ) ->
+        case ( gets "access_token", gets "id_token", gets "error" ) of
+            ( Just accessToken, _, _ ) ->
                 Internal.parseToken
                     accessToken
                     (gets "token_type")
@@ -68,7 +68,11 @@ parse { hash } =
                     (QS.all "scope" qs)
                     (gets "state")
 
-            ( _, Just error ) ->
+            ( _, Just idToken, _ ) ->
+                Internal.parseIDToken
+                    idToken
+
+            ( _, _, Just error ) ->
                 Internal.parseError
                     error
                     (gets "error_description")


### PR DESCRIPTION
OpenID Connect is based on OAuth but returns a special token (a jwt) instead of a regular oauth token.
This PR add a basic support for receiving such a token.