### PR TITLE
fix parse target `hash` to `search` at Implicit Flow

### DIFF
--- a/src/OAuth/Implicit.elm
+++ b/src/OAuth/Implicit.elm
@@ -48,10 +48,10 @@ Fails with `ParseErr Empty` when there's nothing
 
 -}
 parse : Navigation.Location -> Result ParseErr ResponseToken
-parse { hash } =
+parse { search } =
     let
         qs =
-            QS.parse ("?" ++ String.dropLeft 1 hash)
+            QS.parse ("?" ++ String.dropLeft 1 search)
 
         gets =
             flip (QS.one QS.string) qs


### PR DESCRIPTION
First of all, thanks to a great module.

I found that this module doesn't parse query string of callback URL at Implicit Flow.

So I just changed parse target. `hash` to `search`.
Please look at this short fix. Thanks.
