### PR TITLE
Upgrade to elm/http version 2.0.0

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -15,7 +15,7 @@
     "dependencies": {
         "elm/core": "1.0.0 <= v < 2.0.0",
         "elm/url": "1.0.0 <= v < 2.0.0",
-        "elm/http": "1.0.0 <= v < 2.0.0",
+        "elm/http": "2.0.0 <= v < 3.0.0",
         "elm/json": "1.0.0 <= v < 2.0.0",
         "truqu/elm-base64": "2.0.0 <= v < 3.0.0",
 

--- a/examples/elm.json
+++ b/examples/elm.json
@@ -8,17 +8,19 @@
     "dependencies": {
         "direct": {
             "elm/browser": "1.0.0",
-            "elm/core": "1.0.0",
+            "elm/core": "1.0.2",
             "elm/html": "1.0.0",
-            "elm/http": "1.0.0",
-            "elm/json": "1.0.0",
+            "elm/http": "2.0.0",
+            "elm/json": "1.1.0",
             "elm/url": "1.0.0",
             "truqu/elm-base64": "2.0.4"
         },
         "indirect": {
             "elm/regex": "1.0.0",
             "elm/time": "1.0.0",
-            "elm/virtual-dom": "1.0.0"
+            "elm/virtual-dom": "1.0.0",
+            "elm/bytes": "1.0.7",
+            "elm/file": "1.0.1"
         }
     },
     "test-dependencies": {

--- a/examples/implicit/Main.elm
+++ b/examples/implicit/Main.elm
@@ -53,16 +53,15 @@ type
 
 getUserInfo : OAuthConfiguration -> OAuth.Token -> Cmd Msg
 getUserInfo { profileEndpoint, profileDecoder } token =
-    Http.send GotUserInfo <|
-        Http.request
-            { method = "GET"
-            , body = Http.emptyBody
-            , headers = OAuth.useToken token []
-            , withCredentials = False
-            , url = Url.toString profileEndpoint
-            , expect = Http.expectJson profileDecoder
-            , timeout = Nothing
-            }
+    Http.request
+        { method = "GET"
+        , body = Http.emptyBody
+        , headers = OAuth.useToken token []
+        , url = Url.toString profileEndpoint
+        , expect = Http.expectJson GotUserInfo profileDecoder
+        , timeout = Nothing
+        , tracker = Nothing
+        }
 
 
 

--- a/src/Internal.elm
+++ b/src/Internal.elm
@@ -247,7 +247,7 @@ makeRequest tagger url headers body =
     }
 
 
-authenticationResponseHandler : Json.Decoder AuthenticationSuccess -> Http.Response String -> Result HttpError AuthenticationSuccess
+authenticationResponseHandler : Json.Decoder a -> Http.Response String -> Result HttpError a
 authenticationResponseHandler decoder response =
     case response of
         Http.BadUrl_ string ->

--- a/src/OAuth.elm
+++ b/src/OAuth.elm
@@ -1,6 +1,7 @@
 module OAuth exposing
     ( Token, useToken, tokenToString, tokenFromString
     , ErrorCode(..), errorCodeToString, errorCodeFromString
+    , HttpError(..)
     , TokenType, TokenString, makeToken, makeRefreshToken
     )
 
@@ -41,6 +42,11 @@ used.
 @docs ErrorCode, errorCodeToString, errorCodeFromString
 
 
+## Http request errors
+
+@docs HttpError
+
+
 ## Decoders & Parsers Utils (advanced)
 
 @docs TokenType, TokenString, makeToken, makeRefreshToken
@@ -66,6 +72,16 @@ import Http as Http
 -}
 type Token
     = Bearer String
+
+
+{-| Like `Http.Error`, except `BadStatus` includes the returned body.
+-}
+type HttpError
+    = BadUrl String
+    | Timeout
+    | NetworkError
+    | BadStatus Int String
+    | BadBody String
 
 
 {-| Alias for readability

--- a/src/OAuth/AuthorizationCode.elm
+++ b/src/OAuth/AuthorizationCode.elm
@@ -359,8 +359,13 @@ type alias Credentials =
 
 {-| Builds a the request components required to get a token from an authorization code
 
-    let req : Http.Request AuthenticationSuccess
-        req = makeTokenRequest authentication |> Http.request
+    type Msg
+        = ReceiveTokenRequest (Result HttpError AuthenticationSuccess)
+    ...
+
+    let req : RequestParts msg
+        req = makeTokenRequest ReceiveTokenReqest authentication
+    ...
 
 -}
 makeTokenRequest : (Result HttpError AuthenticationSuccess -> msg) -> Authentication -> RequestParts msg
@@ -392,7 +397,7 @@ makeTokenRequest tagger { credentials, code, url, redirectUri } =
 You'll want this if you need to use `defaultAuthenticationErrorDecoder` on the `body` of a `BadStatus` response.
 
 -}
-authenticationResponseHandler : Json.Decoder AuthenticationSuccess -> Http.Response String -> Result HttpError AuthenticationSuccess
+authenticationResponseHandler : Json.Decoder a -> Http.Response String -> Result HttpError a
 authenticationResponseHandler =
     Internal.authenticationResponseHandler
 
@@ -414,7 +419,7 @@ defaultAuthenticationSuccessDecoder =
 {-| Json decoder for an errored response.
 
     case res of
-        Err (OAuth.BadStatus { body }) ->
+        Err (OAuth.BadStatus _ body) ->
             case Json.decodeString OAuth.AuthorizationCode.defaultAuthenticationErrorDecoder body of
                 Ok { error, errorDescription } ->
                     doSomething

--- a/src/OAuth/AuthorizationCode.elm
+++ b/src/OAuth/AuthorizationCode.elm
@@ -1,7 +1,7 @@
 module OAuth.AuthorizationCode exposing
     ( Authorization, AuthorizationResult(..), AuthorizationSuccess, AuthorizationError, parseCode, makeAuthUrl
     , parseCodeWith
-    , Authentication, Credentials, AuthenticationSuccess, AuthenticationError, RequestParts, makeTokenRequest
+    , Authentication, Credentials, AuthenticationSuccess, AuthenticationError, RequestParts, makeTokenRequest, authenticationResponseHandler
     , Parsers, defaultParsers, defaultCodeParser, defaultErrorParser, defaultAuthorizationSuccessParser, defaultAuthorizationErrorParser
     , defaultAuthenticationSuccessDecoder, defaultAuthenticationErrorDecoder, defaultExpiresInDecoder, defaultScopeDecoder, lenientScopeDecoder, defaultTokenDecoder, defaultRefreshTokenDecoder, defaultErrorDecoder, defaultErrorDescriptionDecoder, defaultErrorUriDecoder
     )
@@ -35,7 +35,7 @@ request.
 
 ## Authenticate
 
-@docs Authentication, Credentials, AuthenticationSuccess, AuthenticationError, RequestParts, makeTokenRequest
+@docs Authentication, Credentials, AuthenticationSuccess, AuthenticationError, RequestParts, makeTokenRequest, authenticationResponseHandler
 
 
 ## Query Parsers
@@ -387,6 +387,16 @@ makeTokenRequest tagger { credentials, code, url, redirectUri } =
     makeRequest tagger url headers body
 
 
+{-| Allows you to adjust `RequestParts.expect` for an `Oauth.HttpError`.
+
+You'll want this if you need to use `defaultAuthenticationErrorDecoder` on the `body` of a `BadStatus` response.
+
+-}
+authenticationResponseHandler : Json.Decoder AuthenticationSuccess -> Http.Response String -> Result HttpError AuthenticationSuccess
+authenticationResponseHandler =
+    Internal.authenticationResponseHandler
+
+
 
 --
 -- Json Decoders
@@ -404,7 +414,7 @@ defaultAuthenticationSuccessDecoder =
 {-| Json decoder for an errored response.
 
     case res of
-        Err (Http.BadStatus { body }) ->
+        Err (OAuth.BadStatus { body }) ->
             case Json.decodeString OAuth.AuthorizationCode.defaultAuthenticationErrorDecoder body of
                 Ok { error, errorDescription } ->
                     doSomething

--- a/src/OAuth/ClientCredentials.elm
+++ b/src/OAuth/ClientCredentials.elm
@@ -31,7 +31,7 @@ request.
 import Http
 import Internal as Internal exposing (..)
 import Json.Decode as Json
-import OAuth exposing (ErrorCode(..), Token, errorCodeFromString)
+import OAuth exposing (ErrorCode(..), HttpError, Token, errorCodeFromString)
 import Url exposing (Url)
 import Url.Builder as Builder
 
@@ -126,14 +126,14 @@ type alias AuthenticationError =
 {-| Parts required to build a request. This record is given to `Http.request` in order
 to create a new request and may be adjusted at will.
 -}
-type alias RequestParts a =
+type alias RequestParts msg =
     { method : String
     , headers : List Http.Header
     , url : String
     , body : Http.Body
-    , expect : Http.Expect a
+    , expect : Http.Expect msg
     , timeout : Maybe Float
-    , withCredentials : Bool
+    , tracker : Maybe String
     }
 
 
@@ -143,8 +143,8 @@ type alias RequestParts a =
         req = makeTokenRequest authentication |> Http.request
 
 -}
-makeTokenRequest : Authentication -> RequestParts AuthenticationSuccess
-makeTokenRequest { credentials, scope, url } =
+makeTokenRequest : (Result HttpError AuthenticationSuccess -> msg) -> Authentication -> RequestParts msg
+makeTokenRequest tagger { credentials, scope, url } =
     let
         body =
             [ Builder.string "grant_type" "client_credentials" ]
@@ -159,7 +159,7 @@ makeTokenRequest { credentials, scope, url } =
                     , secret = credentials.secret
                     }
     in
-    makeRequest url headers body
+    makeRequest tagger url headers body
 
 
 

--- a/src/OAuth/Password.elm
+++ b/src/OAuth/Password.elm
@@ -32,7 +32,7 @@ request.
 import Http
 import Internal as Internal exposing (..)
 import Json.Decode as Json
-import OAuth exposing (ErrorCode(..), Token, errorCodeFromString)
+import OAuth exposing (ErrorCode(..), HttpError, Token, errorCodeFromString)
 import Url exposing (Url)
 import Url.Builder as Builder
 
@@ -129,14 +129,14 @@ type alias AuthenticationError =
 {-| Parts required to build a request. This record is given to `Http.request` in order
 to create a new request and may be adjusted at will.
 -}
-type alias RequestParts a =
+type alias RequestParts msg =
     { method : String
     , headers : List Http.Header
     , url : String
     , body : Http.Body
-    , expect : Http.Expect a
+    , expect : Http.Expect msg
     , timeout : Maybe Float
-    , withCredentials : Bool
+    , tracker : Maybe String
     }
 
 
@@ -146,8 +146,8 @@ type alias RequestParts a =
         req = makeTokenRequest authentication |> Http.request
 
 -}
-makeTokenRequest : Authentication -> RequestParts AuthenticationSuccess
-makeTokenRequest { credentials, password, scope, url, username } =
+makeTokenRequest : (Result HttpError AuthenticationSuccess -> msg) -> Authentication -> RequestParts msg
+makeTokenRequest tagger { credentials, password, scope, url, username } =
     let
         body =
             [ Builder.string "grant_type" "password"
@@ -161,7 +161,7 @@ makeTokenRequest { credentials, password, scope, url, username } =
         headers =
             makeHeaders credentials
     in
-    makeRequest url headers body
+    makeRequest tagger url headers body
 
 
 

--- a/src/OAuth/Refresh.elm
+++ b/src/OAuth/Refresh.elm
@@ -29,7 +29,7 @@ can be used in subsequent requests.
 import Http
 import Internal as Internal exposing (..)
 import Json.Decode as Json
-import OAuth exposing (ErrorCode(..), Token, errorCodeFromString)
+import OAuth exposing (ErrorCode(..), HttpError, Token, errorCodeFromString)
 import Url exposing (Url)
 import Url.Builder as Builder
 
@@ -128,7 +128,7 @@ type alias RequestParts a =
     , body : Http.Body
     , expect : Http.Expect a
     , timeout : Maybe Float
-    , withCredentials : Bool
+    , tracker : Maybe String
     }
 
 
@@ -138,8 +138,8 @@ type alias RequestParts a =
         req = makeTokenRequest reqParts |> Http.request
 
 -}
-makeTokenRequest : Authentication -> RequestParts AuthenticationSuccess
-makeTokenRequest { credentials, scope, token, url } =
+makeTokenRequest : (Result HttpError AuthenticationSuccess -> msg) -> Authentication -> RequestParts msg
+makeTokenRequest tagger { credentials, scope, token, url } =
     let
         body =
             [ Builder.string "grant_type" "refresh_token"
@@ -152,7 +152,7 @@ makeTokenRequest { credentials, scope, token, url } =
         headers =
             makeHeaders credentials
     in
-    makeRequest url headers body
+    makeRequest tagger url headers body
 
 
 


### PR DESCRIPTION
This is similar to @michaelwebb76's PR #16, but it provides the `body` with a `BadStatus` response, so that the `AuthorizationCode` request can parse the returned JSON for the error.

I have tested the `AuthorizationCode` branch in [billstclair/elm-oauth-middleware](https://github.com/billstclair/elm-oauth-middleware/commit/2d04f626bee1e945c64e91dd15fcc4d9a7bb9811).

PR #16 is simpler, and should be sufficient for other than `AuthorizationCode` errors. If you choose that one, I'll probably make my own copy of the `AuthorizationCode` code in `elm-oauth-middleware`.