### PR TITLE
Tiny fix to README code: OAuth.Implicit.parseToken

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ init { randomBytes } origin _ =
         OAuth.Empty ->
             ( model, Cmd.none )
 
-        OAuth.Success { token, state } ->
+        OAuth.Implicit.Success { token, state } ->
             if state /= Just model.state then
                 ( { model | error = Just "'state' mismatch, request likely forged by an adversary!" }
                 , Cmd.none

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ init { randomBytes } origin _ =
             , state = randomBytes
             }
     in
-    case OAuth.parseToken origin of
+    case OAuth.Implicit.parseToken origin of
         OAuth.Empty ->
             ( model, Cmd.none )
 


### PR DESCRIPTION
Tiny fix when going through the README.

The example used OAuth.parseToken

I think the actual function is in OAuth.Implicit.parseToken

Ditto OAuth.Success -> OAuth.Implicit.Success