### PR TITLE
More advanced control for encoders, parsers and url builders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,273 @@
+## v8.0.0 (2021-??-??)
+
+- Allow more advanced control for tweaking parsers, decoders and url builders. This is particularly useful for applications integrating with systems which are either not strictly following the OAuth2.0 specifications, or, systems who introduce custom fields of some importance for the underlying application. (see #29, #23, #21)
+
+- Update dependencies for base64 encoding
+
+### Diff
+
+#### `OAuth` - MINOR
+
+- Added:
+
+  ```elm
+  type GrantType
+      = AuthorizationCode
+      | Password
+      | ClientCredentials
+      | RefreshToken
+      | CustomGrant String
+
+  grantTypeToString : GrantType -> String
+  ```
+
+  ```elm
+  type ResponseType
+      = Code
+      | Token
+      | CustomResponse String
+
+  responseTypeToString : ResponseType -> String
+  ```
+
+#### `OAuth.Implicit` - MAJOR 
+
+- Added:
+
+  ```elm
+  makeAuthorizationUrlWith :
+      ResponseType
+      -> Dict String String
+      -> Authorization
+      -> Url
+  ```
+
+- Changed: 
+
+  ```elm
+  -- type alias Parsers =
+  --     { tokenParser :
+  --           Query.Parser (Maybe Token)
+  --     , errorParser :
+  --           Query.Parser (Maybe ErrorCode)
+  --     , authorizationSuccessParser :
+  --           String -> Query.Parser AuthorizationSuccess
+  --     , authorizationErrorParser :
+  --           ErrorCode -> Query.Parser AuthorizationError
+  --     }
+
+  type alias Parsers error success =
+      { tokenParser :
+            Query.Parser (Maybe Token)
+      , errorParser :
+            Query.Parser (Maybe ErrorCode)
+      , authorizationSuccessParser :
+            String -> Query.Parser success
+      , authorizationErrorParser :
+            ErrorCode -> Query.Parser error
+      }
+  ```
+
+  ```elm
+  -- defaultParsers : Parsers
+  defaultParsers : Parsers AuthorizationError AuthorizationSuccess
+  ```
+
+  ```elm
+  -- parseTokenWith : Parsers -> Url -> AuthorizationResult
+  parseTokenWith : Parsers error success -> Url -> AuthorizationResultWith error success
+  ```
+
+#### `OAuth.AuthorizationCode` - MAJOR
+
+- Added:
+
+  ```elm
+  makeAuthorizationUrlWith :
+      ResponseType
+      -> Dict String String
+      -> Authorization
+      -> Url
+  ```
+
+  ```elm
+  makeTokenRequestWith :
+      OAuth.GrantType
+      -> Json.Decoder success
+      -> Dict String String
+      -> (Result Http.Error success -> msg)
+      -> Authentication
+      -> RequestParts msg
+  ```
+
+- Changed:
+
+  ```elm
+  -- type AuthorizationResult
+  --     = Empty
+  --     | Error AuthorizationError
+  --     | Success AuthorizationSuccess
+
+  type alias AuthorizationResult =
+      AuthorizationResultWith AuthorizationError AuthorizationSuccess
+
+  type AuthorizationResultWith error success
+      = Empty
+      | Error error
+      | Success success
+  ```
+
+  ```elm
+  -- type alias Parsers =
+  --     { codeParser :
+  --           Query.Parser (Maybe String)
+  --     , errorParser :
+  --           Query.Parser (Maybe ErrorCode)
+  --     , authorizationSuccessParser :
+  --           String -> Query.Parser AuthorizationSuccess
+  --     , authorizationErrorParser :
+  --           ErrorCode -> Query.Parser AuthorizationError
+  --     }
+
+  type alias Parsers error success =
+      { codeParser :
+            Query.Parser (Maybe String)
+      , errorParser :
+            Query.Parser (Maybe ErrorCode)
+      , authorizationSuccessParser :
+            String -> Query.Parser success
+      , authorizationErrorParser :
+            ErrorCode -> Query.Parser error
+      }
+  ```
+
+  ```elm
+  -- defaultParsers : Parsers
+  defaultParsers : Parsers AuthorizationError AuthorizationSuccess
+  ```
+
+  ```elm
+  -- parseCodeWith : Parsers -> Url -> AuthorizationResult
+  parseCodeWith : Parsers error success -> Url -> AuthorizationResultWith error success
+  ```
+
+#### `OAuth.AuthorizationCode.PKCE` - MAJOR 
+
+- Added:
+
+  ```elm
+  makeAuthorizationUrlWith :
+      ResponseType
+      -> Dict String String
+      -> Authorization
+      -> Url
+  ```
+
+  ```elm
+  makeTokenRequestWith :
+      OAuth.GrantType
+      -> Json.Decoder success
+      -> Dict String String
+      -> (Result Http.Error success -> msg)
+      -> Authentication
+      -> RequestParts msg
+  ```
+
+- Changed:
+
+  ```elm
+  -- type AuthorizationResult
+  --     = Empty
+  --     | Error AuthorizationError
+  --     | Success AuthorizationSuccess
+
+  type alias AuthorizationResult =
+      AuthorizationResultWith AuthorizationError AuthorizationSuccess
+
+  type AuthorizationResultWith error success
+      = Empty
+      | Error error
+      | Success success
+  ```
+
+  ```elm
+  -- type alias Parsers =
+  --     { codeParser :
+  --           Query.Parser (Maybe String)
+  --     , errorParser :
+  --           Query.Parser (Maybe ErrorCode)
+  --     , authorizationSuccessParser :
+  --           String -> Query.Parser AuthorizationSuccess
+  --     , authorizationErrorParser :
+  --           ErrorCode -> Query.Parser AuthorizationError
+  --     }
+
+  type alias Parsers error success =
+      { codeParser :
+            Query.Parser (Maybe String)
+      , errorParser :
+            Query.Parser (Maybe ErrorCode)
+      , authorizationSuccessParser :
+            String -> Query.Parser success
+      , authorizationErrorParser :
+            ErrorCode -> Query.Parser error
+      }
+  ```
+
+  ```elm
+  -- defaultParsers : Parsers
+  defaultParsers : Parsers AuthorizationError AuthorizationSuccess
+  ```
+
+  ```elm
+  -- parseCodeWith : Parsers -> Url -> AuthorizationResult
+  parseCodeWith : Parsers error success -> Url -> AuthorizationResultWith error success
+  ```
+
+
+#### `OAuth.ClientCredentials` - MINOR 
+
+- Added:
+
+  ```elm
+  makeTokenRequestWith :
+      GrantType
+      -> Json.Decoder success
+      -> Dict String String
+      -> (Result Http.Error success -> msg)
+      -> Authentication
+      -> RequestParts msg
+  ```
+
+#### `OAuth.Password` - MINOR 
+
+- Added:
+
+  ```elm
+  makeTokenRequestWith :
+      GrantType
+      -> Json.Decoder success
+      -> Dict String String
+      -> (Result Http.Error success -> msg)
+      -> Authentication
+      -> RequestParts msg
+  ```
+
+
+#### `OAuth.Refresh` - MINOR 
+
+- Added:
+
+  ```elm
+  makeTokenRequestWith :
+      GrantType
+      -> Json.Decoder success
+      -> Dict String String
+      -> (Result Http.Error success -> msg)
+      -> Authentication
+      -> RequestParts msg
+  ```
+
 ## v7.0.1 (2020-12-05)
 
 - Updated dependency `ivadzy/bbase64@1.1.1` renamed as `chelovek0v/bbase64@1.0.1`

--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "truqu/elm-oauth2",
     "summary": "OAuth 2.0 client-side utils",
     "license": "MIT",
-    "version": "7.0.1",
+    "version": "8.0.0",
     "exposed-modules": [
         "OAuth",
         "OAuth.AuthorizationCode",

--- a/examples/providers/facebook/implicit/Main.elm
+++ b/examples/providers/facebook/implicit/Main.elm
@@ -497,7 +497,7 @@ errorParser =
 
 {-| Put everything together and rely on `OAuth.parseTokenWith` instead of the default parser
 -}
-parsers : OAuth.Parsers
+parsers : OAuth.Parsers OAuth.AuthorizationError OAuth.AuthorizationSuccess
 parsers =
     { tokenParser = tokenParser
     , errorParser = errorParser

--- a/src/OAuth.elm
+++ b/src/OAuth.elm
@@ -1,5 +1,6 @@
 module OAuth exposing
     ( Token, useToken, tokenToString, tokenFromString
+    , ResponseType(..), responseTypeToString, GrantType(..), grantTypeToString
     , ErrorCode(..), errorCodeToString, errorCodeFromString
     , TokenType, TokenString, makeToken, makeRefreshToken
     )
@@ -37,6 +38,11 @@ used.
 ## Token
 
 @docs Token, useToken, tokenToString, tokenFromString
+
+
+## Response & Grant types
+
+@docs ResponseType, responseTypeToString, GrantType, grantTypeToString
 
 
 ## ErrorCode
@@ -158,6 +164,69 @@ tokenFromString str =
 
         _ ->
             Nothing
+
+
+
+--
+-- ResponseType / GrandType
+--
+
+
+{-| Describes the desired type of response to an authorization. Use `Code` to ask for an
+authorization code and continue with the according flow. Use `Token` to do an implicit
+authentication and directly retrieve a `Token` from the authorization. If need be, you may provide a
+custom response type should the server returns a non-standard response type.
+-}
+type ResponseType
+    = Code
+    | Token
+    | CustomResponse String
+
+
+{-| Gets the `String` representation of a `ResponseType`.
+-}
+responseTypeToString : ResponseType -> String
+responseTypeToString r =
+    case r of
+        Code ->
+            "code"
+
+        Token ->
+            "token"
+
+        CustomResponse str ->
+            str
+
+
+{-| Describes the desired type of grant to an authentication.
+-}
+type GrantType
+    = AuthorizationCode
+    | Password
+    | ClientCredentials
+    | RefreshToken
+    | CustomGrant String
+
+
+{-| Gets the `String` representation of a `GrantType`
+-}
+grantTypeToString : GrantType -> String
+grantTypeToString g =
+    case g of
+        AuthorizationCode ->
+            "authorization_code"
+
+        Password ->
+            "password"
+
+        ClientCredentials ->
+            "client_credentials"
+
+        RefreshToken ->
+            "refresh_token"
+
+        CustomGrant str ->
+            str
 
 
 

--- a/src/OAuth/AuthorizationCode/PKCE.elm
+++ b/src/OAuth/AuthorizationCode/PKCE.elm
@@ -1,8 +1,10 @@
 module OAuth.AuthorizationCode.PKCE exposing
-    ( CodeVerifier, CodeChallenge, codeVerifierFromBytes, codeVerifierToString, mkCodeChallenge, codeChallengeToString
-    , makeAuthorizationUrl, parseCode, Authorization, AuthorizationCode, AuthorizationResult(..), AuthorizationSuccess, AuthorizationError
+    ( CodeVerifier(..), CodeChallenge(..), codeVerifierFromBytes, codeVerifierToString, mkCodeChallenge, codeChallengeToString
+    , makeAuthorizationUrl, Authorization, parseCode, AuthorizationResult, AuthorizationError, AuthorizationSuccess, AuthorizationCode
     , makeTokenRequest, Authentication, Credentials, AuthenticationSuccess, AuthenticationError, RequestParts
     , defaultAuthenticationSuccessDecoder, defaultAuthenticationErrorDecoder
+    , makeAuthorizationUrlWith, AuthorizationResultWith(..)
+    , makeTokenRequestWith
     , defaultExpiresInDecoder, defaultScopeDecoder, lenientScopeDecoder, defaultTokenDecoder, defaultRefreshTokenDecoder, defaultErrorDecoder, defaultErrorDescriptionDecoder, defaultErrorUriDecoder
     , parseCodeWith, Parsers, defaultParsers, defaultCodeParser, defaultErrorParser, defaultAuthorizationSuccessParser, defaultAuthorizationErrorParser
     )
@@ -41,7 +43,7 @@ of this flow.
 
 ## Authorize
 
-@docs makeAuthorizationUrl, parseCode, Authorization, AuthorizationCode, AuthorizationResult, AuthorizationSuccess, AuthorizationError
+@docs makeAuthorizationUrl, Authorization, parseCode, AuthorizationResult, AuthorizationError, AuthorizationSuccess, AuthorizationCode
 
 
 ## Authenticate
@@ -54,12 +56,25 @@ of this flow.
 @docs defaultAuthenticationSuccessDecoder, defaultAuthenticationErrorDecoder
 
 
-## JSON Decoders (advanced)
+## Custom Decoders & Parsers (advanced)
+
+
+### Authorize
+
+@docs makeAuthorizationUrlWith, AuthorizationResultWith
+
+
+### Authenticate
+
+@docs makeTokenRequestWith
+
+
+### Json Decoders
 
 @docs defaultExpiresInDecoder, defaultScopeDecoder, lenientScopeDecoder, defaultTokenDecoder, defaultRefreshTokenDecoder, defaultErrorDecoder, defaultErrorDescriptionDecoder, defaultErrorUriDecoder
 
 
-## Query Parsers (advanced)
+### Query Parsers
 
 @docs parseCodeWith, Parsers, defaultParsers, defaultCodeParser, defaultErrorParser, defaultAuthorizationSuccessParser, defaultAuthorizationErrorParser
 
@@ -67,10 +82,12 @@ of this flow.
 
 import Base64.Encode as Base64
 import Bytes exposing (Bytes)
+import Dict as Dict exposing (Dict)
 import Http
 import Internal as Internal exposing (..)
 import Json.Decode as Json
-import OAuth exposing (ErrorCode, Token, errorCodeFromString)
+import OAuth exposing (ErrorCode, GrantType(..), ResponseType(..), Token, errorCodeFromString)
+import OAuth.AuthorizationCode
 import SHA256 as SHA256
 import Url exposing (Url)
 import Url.Builder as Builder
@@ -248,26 +265,24 @@ type alias AuthorizationSuccess =
   - Success: a successfully parsed token and response
 
 -}
-type AuthorizationResult
+type alias AuthorizationResult =
+    AuthorizationResultWith AuthorizationError AuthorizationSuccess
+
+
+{-| A parameterized 'AuthorizationResult'. See 'parseCodeWith'.
+-}
+type AuthorizationResultWith error success
     = Empty
-    | Error AuthorizationError
-    | Success AuthorizationSuccess
+    | Error error
+    | Success success
 
 
 {-| Redirects the resource owner (user) to the resource provider server using the specified
 authorization flow.
 -}
 makeAuthorizationUrl : Authorization -> Url
-makeAuthorizationUrl { clientId, url, redirectUri, scope, state, codeChallenge } =
-    Internal.makeAuthorizationUrl
-        Internal.Code
-        { clientId = clientId
-        , url = url
-        , redirectUri = redirectUri
-        , scope = scope
-        , state = state
-        , codeChallenge = Just <| codeChallengeToString codeChallenge
-        }
+makeAuthorizationUrl =
+    makeAuthorizationUrlWith Code Dict.empty
 
 
 {-| Parse the location looking for a parameters set by the resource provider server after
@@ -279,87 +294,6 @@ Returns `AuthorizationResult Empty` when there's nothing.
 parseCode : Url -> AuthorizationResult
 parseCode =
     parseCodeWith defaultParsers
-
-
-
---
--- Query Parsers (advanced)
---
-
-
-{-| See `parseCode`, but gives you the ability to provide your own custom parsers.
--}
-parseCodeWith : Parsers -> Url -> AuthorizationResult
-parseCodeWith { codeParser, errorParser, authorizationSuccessParser, authorizationErrorParser } url_ =
-    let
-        url =
-            { url_ | path = "/" }
-    in
-    case Url.parse (Url.top <?> Query.map2 Tuple.pair codeParser errorParser) url of
-        Just ( Just code, _ ) ->
-            parseUrlQuery url Empty (Query.map Success <| authorizationSuccessParser code)
-
-        Just ( _, Just error ) ->
-            parseUrlQuery url Empty (Query.map Error <| authorizationErrorParser error)
-
-        _ ->
-            Empty
-
-
-{-| Parsers used in the 'parseCode' function.
-
-  - codeParser: looks for a 'code' string
-  - errorParser: looks for an 'error' to build a corresponding `ErrorCode`
-  - authorizationSuccessParser: selected when the `tokenParser` succeeded to parse the remaining parts
-  - authorizationErrorParser: selected when the `errorParser` succeeded to parse the remaining parts
-
--}
-type alias Parsers =
-    { codeParser : Query.Parser (Maybe String)
-    , errorParser : Query.Parser (Maybe ErrorCode)
-    , authorizationSuccessParser : String -> Query.Parser AuthorizationSuccess
-    , authorizationErrorParser : ErrorCode -> Query.Parser AuthorizationError
-    }
-
-
-{-| Default parsers according to RFC-6749
--}
-defaultParsers : Parsers
-defaultParsers =
-    { codeParser = defaultCodeParser
-    , errorParser = defaultErrorParser
-    , authorizationSuccessParser = defaultAuthorizationSuccessParser
-    , authorizationErrorParser = defaultAuthorizationErrorParser
-    }
-
-
-{-| Default 'code' parser according to RFC-6749
--}
-defaultCodeParser : Query.Parser (Maybe String)
-defaultCodeParser =
-    Query.string "code"
-
-
-{-| Default 'error' parser according to RFC-6749
--}
-defaultErrorParser : Query.Parser (Maybe ErrorCode)
-defaultErrorParser =
-    errorParser errorCodeFromString
-
-
-{-| Default response success parser according to RFC-6749
--}
-defaultAuthorizationSuccessParser : String -> Query.Parser AuthorizationSuccess
-defaultAuthorizationSuccessParser code =
-    Query.map (AuthorizationSuccess code)
-        stateParser
-
-
-{-| Default response error parser according to RFC-6749
--}
-defaultAuthorizationErrorParser : ErrorCode -> Query.Parser AuthorizationError
-defaultAuthorizationErrorParser =
-    authorizationErrorParser
 
 
 
@@ -492,28 +426,8 @@ type alias Credentials =
 
 -}
 makeTokenRequest : (Result Http.Error AuthenticationSuccess -> msg) -> Authentication -> RequestParts msg
-makeTokenRequest toMsg { credentials, code, codeVerifier, url, redirectUri } =
-    let
-        body =
-            [ Builder.string "grant_type" "authorization_code"
-            , Builder.string "client_id" credentials.clientId
-            , Builder.string "redirect_uri" (makeRedirectUri redirectUri)
-            , Builder.string "code" code
-            , Builder.string "code_verifier" (codeVerifierToString codeVerifier)
-            ]
-                |> Builder.toQuery
-                |> String.dropLeft 1
-
-        headers =
-            makeHeaders <|
-                case credentials.secret of
-                    Nothing ->
-                        Nothing
-
-                    Just secret ->
-                        Just { clientId = credentials.clientId, secret = secret }
-    in
-    makeRequest toMsg url headers body
+makeTokenRequest =
+    makeTokenRequestWith AuthorizationCode defaultAuthenticationSuccessDecoder Dict.empty
 
 
 
@@ -557,6 +471,150 @@ defaultAuthenticationSuccessDecoder =
 defaultAuthenticationErrorDecoder : Json.Decoder AuthenticationError
 defaultAuthenticationErrorDecoder =
     Internal.authenticationErrorDecoder defaultErrorDecoder
+
+
+
+--
+-- Custom Decoders & Parsers (advanced)
+--
+
+
+{-| Like 'makeAuthorizationUrl', but gives you the ability to specify a custom response type
+and extra fields to be set on the query.
+
+    makeAuthorizationUrl : Authorization -> Url
+    makeAuthorizationUrl =
+        makeAuthorizationUrlWith Code Dict.empty
+
+For example, to interact with a service implementing `OpenID+Connect` you may require a different
+token type and an extra query parameter as such:
+
+    makeAuthorizationUrlWith
+        (CustomResponse "code+id_token")
+        (Dict.fromList [ ( "resource", "001" ) ])
+        authorization
+
+-}
+makeAuthorizationUrlWith : ResponseType -> Dict String String -> Authorization -> Url
+makeAuthorizationUrlWith responseType extraFields { clientId, url, redirectUri, scope, state, codeChallenge } =
+    let
+        extraInternalFields =
+            Dict.fromList
+                [ ( "code_challenge", codeChallengeToString codeChallenge )
+                , ( "code_challenge_method", "S256" )
+                ]
+    in
+    OAuth.AuthorizationCode.makeAuthorizationUrlWith
+        responseType
+        (Dict.union extraFields extraInternalFields)
+        { clientId = clientId
+        , url = url
+        , redirectUri = redirectUri
+        , scope = scope
+        , state = state
+        }
+
+
+{-| See `parseCode`, but gives you the ability to provide your own custom parsers.
+-}
+parseCodeWith : Parsers error success -> Url -> AuthorizationResultWith error success
+parseCodeWith parsers url =
+    case OAuth.AuthorizationCode.parseCodeWith parsers url of
+        OAuth.AuthorizationCode.Empty ->
+            Empty
+
+        OAuth.AuthorizationCode.Success s ->
+            Success s
+
+        OAuth.AuthorizationCode.Error e ->
+            Error e
+
+
+{-| Like 'makeTokenRequest', but gives you the ability to specify custom grant type and extra
+fields to be set on the query.
+
+    makeTokenRequest : (Result Http.Error AuthenticationSuccess -> msg) -> Authentication -> RequestParts msg
+    makeTokenRequest =
+        makeTokenRequestWith
+            AuthorizationCode
+            defaultAuthenticationSuccessDecoder
+            Dict.empty
+
+-}
+makeTokenRequestWith : GrantType -> Json.Decoder success -> Dict String String -> (Result Http.Error success -> msg) -> Authentication -> RequestParts msg
+makeTokenRequestWith grantType decoder extraFields toMsg { credentials, code, codeVerifier, url, redirectUri } =
+    let
+        extraInternalFields =
+            Dict.fromList
+                [ ( "code_verifier", codeVerifierToString codeVerifier )
+                ]
+    in
+    OAuth.AuthorizationCode.makeTokenRequestWith
+        grantType
+        decoder
+        (Dict.union extraFields extraInternalFields)
+        toMsg
+        { credentials = credentials
+        , code = code
+        , url = url
+        , redirectUri = redirectUri
+        }
+
+
+{-| Parsers used in the 'parseCode' function.
+
+  - codeParser: looks for a 'code' string
+  - errorParser: looks for an 'error' to build a corresponding `ErrorCode`
+  - authorizationSuccessParser: selected when the `tokenParser` succeeded to parse the remaining parts
+  - authorizationErrorParser: selected when the `errorParser` succeeded to parse the remaining parts
+
+-}
+type alias Parsers error success =
+    { codeParser : Query.Parser (Maybe String)
+    , errorParser : Query.Parser (Maybe ErrorCode)
+    , authorizationSuccessParser : String -> Query.Parser success
+    , authorizationErrorParser : ErrorCode -> Query.Parser error
+    }
+
+
+{-| Default parsers according to RFC-6749
+-}
+defaultParsers : Parsers AuthorizationError AuthorizationSuccess
+defaultParsers =
+    { codeParser = defaultCodeParser
+    , errorParser = defaultErrorParser
+    , authorizationSuccessParser = defaultAuthorizationSuccessParser
+    , authorizationErrorParser = defaultAuthorizationErrorParser
+    }
+
+
+{-| Default 'code' parser according to RFC-6749
+-}
+defaultCodeParser : Query.Parser (Maybe String)
+defaultCodeParser =
+    Query.string "code"
+
+
+{-| Default 'error' parser according to RFC-6749
+-}
+defaultErrorParser : Query.Parser (Maybe ErrorCode)
+defaultErrorParser =
+    errorParser errorCodeFromString
+
+
+{-| Default response success parser according to RFC-6749
+-}
+defaultAuthorizationSuccessParser : String -> Query.Parser AuthorizationSuccess
+defaultAuthorizationSuccessParser code =
+    Query.map (AuthorizationSuccess code)
+        stateParser
+
+
+{-| Default response error parser according to RFC-6749
+-}
+defaultAuthorizationErrorParser : ErrorCode -> Query.Parser AuthorizationError
+defaultAuthorizationErrorParser =
+    authorizationErrorParser
 
 
 {-| Json decoder for an 'expire' timestamp

--- a/src/OAuth/Password.elm
+++ b/src/OAuth/Password.elm
@@ -1,7 +1,7 @@
 module OAuth.Password exposing
     ( makeTokenRequest, Authentication, Credentials, AuthenticationSuccess, AuthenticationError, RequestParts
     , defaultAuthenticationSuccessDecoder, defaultAuthenticationErrorDecoder
-    , defaultExpiresInDecoder, defaultScopeDecoder, lenientScopeDecoder, defaultTokenDecoder, defaultRefreshTokenDecoder, defaultErrorDecoder, defaultErrorDescriptionDecoder, defaultErrorUriDecoder
+    , makeTokenRequestWith, defaultExpiresInDecoder, defaultScopeDecoder, lenientScopeDecoder, defaultTokenDecoder, defaultRefreshTokenDecoder, defaultErrorDecoder, defaultErrorDescriptionDecoder, defaultErrorUriDecoder
     )
 
 {-| The resource owner password credentials grant type is suitable in
@@ -29,16 +29,17 @@ request.
 @docs defaultAuthenticationSuccessDecoder, defaultAuthenticationErrorDecoder
 
 
-## JSON Decoders (advanced)
+## Custom Decoders & Parsers (advanced)
 
-@docs defaultExpiresInDecoder, defaultScopeDecoder, lenientScopeDecoder, defaultTokenDecoder, defaultRefreshTokenDecoder, defaultErrorDecoder, defaultErrorDescriptionDecoder, defaultErrorUriDecoder
+@docs makeTokenRequestWith, defaultExpiresInDecoder, defaultScopeDecoder, lenientScopeDecoder, defaultTokenDecoder, defaultRefreshTokenDecoder, defaultErrorDecoder, defaultErrorDescriptionDecoder, defaultErrorUriDecoder
 
 -}
 
+import Dict as Dict exposing (Dict)
 import Http
 import Internal as Internal exposing (..)
 import Json.Decode as Json
-import OAuth exposing (ErrorCode(..), Token, errorCodeFromString)
+import OAuth exposing (ErrorCode(..), GrantType(..), Token, errorCodeFromString, grantTypeToString)
 import Url exposing (Url)
 import Url.Builder as Builder
 
@@ -156,21 +157,8 @@ type alias RequestParts a =
 
 -}
 makeTokenRequest : (Result Http.Error AuthenticationSuccess -> msg) -> Authentication -> RequestParts msg
-makeTokenRequest toMsg { credentials, password, scope, url, username } =
-    let
-        body =
-            [ Builder.string "grant_type" "password"
-            , Builder.string "username" username
-            , Builder.string "password" password
-            ]
-                |> urlAddList "scope" scope
-                |> Builder.toQuery
-                |> String.dropLeft 1
-
-        headers =
-            makeHeaders credentials
-    in
-    makeRequest toMsg url headers body
+makeTokenRequest =
+    makeTokenRequestWith Password defaultAuthenticationSuccessDecoder Dict.empty
 
 
 
@@ -214,6 +202,39 @@ defaultAuthenticationSuccessDecoder =
 defaultAuthenticationErrorDecoder : Json.Decoder AuthenticationError
 defaultAuthenticationErrorDecoder =
     Internal.authenticationErrorDecoder defaultErrorDecoder
+
+
+
+--
+-- Custom Decoders & Parsers (advanced)
+--
+
+
+{-| Like 'makeTokenRequest', but gives you the ability to specify custom grant type and extra
+fields to be set on the query.
+
+    makeTokenRequest : (Result Http.Error AuthenticationSuccess -> msg) -> Authentication -> RequestParts msg
+    makeTokenRequest =
+        makeTokenRequestWith Password defaultAuthenticationSuccessDecoder Dict.empty
+
+-}
+makeTokenRequestWith : GrantType -> Json.Decoder success -> Dict String String -> (Result Http.Error success -> msg) -> Authentication -> RequestParts msg
+makeTokenRequestWith grantType decoder extraFields toMsg { credentials, password, scope, url, username } =
+    let
+        body =
+            [ Builder.string "grant_type" (grantTypeToString grantType)
+            , Builder.string "username" username
+            , Builder.string "password" password
+            ]
+                |> urlAddExtraFields extraFields
+                |> urlAddList "scope" scope
+                |> Builder.toQuery
+                |> String.dropLeft 1
+
+        headers =
+            makeHeaders credentials
+    in
+    makeRequest decoder toMsg url headers body
 
 
 {-| Json decoder for an 'expire' timestamp

--- a/src/OAuth/Refresh.elm
+++ b/src/OAuth/Refresh.elm
@@ -1,7 +1,7 @@
 module OAuth.Refresh exposing
     ( makeTokenRequest, Authentication, Credentials, AuthenticationSuccess, AuthenticationError, RequestParts
     , defaultAuthenticationSuccessDecoder, defaultAuthenticationErrorDecoder
-    , defaultExpiresInDecoder, defaultScopeDecoder, lenientScopeDecoder, defaultTokenDecoder, defaultRefreshTokenDecoder, defaultErrorDecoder, defaultErrorDescriptionDecoder, defaultErrorUriDecoder
+    , makeTokenRequestWith, defaultExpiresInDecoder, defaultScopeDecoder, lenientScopeDecoder, defaultTokenDecoder, defaultRefreshTokenDecoder, defaultErrorDecoder, defaultErrorDescriptionDecoder, defaultErrorUriDecoder
     )
 
 {-| If the authorization server issued a refresh token to the client, the
@@ -26,16 +26,17 @@ can be used in subsequent requests.
 @docs defaultAuthenticationSuccessDecoder, defaultAuthenticationErrorDecoder
 
 
-## JSON Decoders (advanced)
+## Custom Decoders & Parsers (advanced)
 
-@docs defaultExpiresInDecoder, defaultScopeDecoder, lenientScopeDecoder, defaultTokenDecoder, defaultRefreshTokenDecoder, defaultErrorDecoder, defaultErrorDescriptionDecoder, defaultErrorUriDecoder
+@docs makeTokenRequestWith, defaultExpiresInDecoder, defaultScopeDecoder, lenientScopeDecoder, defaultTokenDecoder, defaultRefreshTokenDecoder, defaultErrorDecoder, defaultErrorDescriptionDecoder, defaultErrorUriDecoder
 
 -}
 
+import Dict as Dict exposing (Dict)
 import Http
 import Internal as Internal exposing (..)
 import Json.Decode as Json
-import OAuth exposing (ErrorCode(..), Token, errorCodeFromString)
+import OAuth exposing (ErrorCode(..), GrantType(..), Token, errorCodeFromString, grantTypeToString)
 import Url exposing (Url)
 import Url.Builder as Builder
 
@@ -147,20 +148,8 @@ type alias RequestParts a =
 
 -}
 makeTokenRequest : (Result Http.Error AuthenticationSuccess -> msg) -> Authentication -> RequestParts msg
-makeTokenRequest toMsg { credentials, scope, token, url } =
-    let
-        body =
-            [ Builder.string "grant_type" "refresh_token"
-            , Builder.string "refresh_token" (extractTokenString token)
-            ]
-                |> urlAddList "scope" scope
-                |> Builder.toQuery
-                |> String.dropLeft 1
-
-        headers =
-            makeHeaders credentials
-    in
-    makeRequest toMsg url headers body
+makeTokenRequest =
+    makeTokenRequestWith RefreshToken defaultAuthenticationSuccessDecoder Dict.empty
 
 
 
@@ -204,6 +193,38 @@ defaultAuthenticationSuccessDecoder =
 defaultAuthenticationErrorDecoder : Json.Decoder AuthenticationError
 defaultAuthenticationErrorDecoder =
     Internal.authenticationErrorDecoder defaultErrorDecoder
+
+
+
+--
+-- Custom Decoders & Parsers (advanced)
+--
+
+
+{-| Like 'makeTokenRequest', but gives you the ability to specify custom grant type and extra
+fields to be set on the query.
+
+    makeTokenRequest : (Result Http.Error AuthenticationSuccess -> msg) -> Authentication -> RequestParts msg
+    makeTokenRequest =
+        makeTokenRequestWith RefreshToken defaultAuthenticationSuccessDecoder Dict.empty
+
+-}
+makeTokenRequestWith : GrantType -> Json.Decoder success -> Dict String String -> (Result Http.Error success -> msg) -> Authentication -> RequestParts msg
+makeTokenRequestWith grantType decoder extraFields toMsg { credentials, scope, token, url } =
+    let
+        body =
+            [ Builder.string "grant_type" (grantTypeToString grantType)
+            , Builder.string "refresh_token" (extractTokenString token)
+            ]
+                |> urlAddList "scope" scope
+                |> urlAddExtraFields extraFields
+                |> Builder.toQuery
+                |> String.dropLeft 1
+
+        headers =
+            makeHeaders credentials
+    in
+    makeRequest decoder toMsg url headers body
 
 
 {-| Json decoder for an 'expire' timestamp


### PR DESCRIPTION
:information_source: Allow more advanced control for tweaking parsers, decoders and url builders. This is particularly useful for applications integrating with systems which are either not strictly following the OAuth2.0 specifications, or, systems who introduce custom fields of some importance for the underlying application. (see #29, #23, #21)

#### `OAuth` - MINOR

- Added:

  ```elm
  type GrantType
      = AuthorizationCode
      | Password
      | ClientCredentials
      | RefreshToken
      | CustomGrant String

  grantTypeToString : GrantType -> String
  ```

  ```elm
  type ResponseType
      = Code
      | Token
      | CustomResponse String

  responseTypeToString : ResponseType -> String
  ```

#### `OAuth.Implicit` - MAJOR 

- Added:

  ```elm
  makeAuthorizationUrlWith :
      ResponseType
      -> Dict String String
      -> Authorization
      -> Url
  ```

- Changed: 

  ```elm
  -- type alias Parsers =
  --     { tokenParser :
  --           Query.Parser (Maybe Token)
  --     , errorParser :
  --           Query.Parser (Maybe ErrorCode)
  --     , authorizationSuccessParser :
  --           String -> Query.Parser AuthorizationSuccess
  --     , authorizationErrorParser :
  --           ErrorCode -> Query.Parser AuthorizationError
  --     }

  type alias Parsers error success =
      { tokenParser :
            Query.Parser (Maybe Token)
      , errorParser :
            Query.Parser (Maybe ErrorCode)
      , authorizationSuccessParser :
            String -> Query.Parser success
      , authorizationErrorParser :
            ErrorCode -> Query.Parser error
      }
  ```

  ```elm
  -- defaultParsers : Parsers
  defaultParsers : Parsers AuthorizationError AuthorizationSuccess
  ```

  ```elm
  -- parseTokenWith : Parsers -> Url -> AuthorizationResult
  parseTokenWith : Parsers error success -> Url -> AuthorizationResultWith error success
  ```

#### `OAuth.AuthorizationCode` - MAJOR

- Added:

  ```elm
  makeAuthorizationUrlWith :
      ResponseType
      -> Dict String String
      -> Authorization
      -> Url
  ```

  ```elm
  makeTokenRequestWith :
      OAuth.GrantType
      -> Json.Decoder success
      -> Dict String String
      -> (Result Http.Error success -> msg)
      -> Authentication
      -> RequestParts msg
  ```

- Changed:

  ```elm
  -- type AuthorizationResult
  --     = Empty
  --     | Error AuthorizationError
  --     | Success AuthorizationSuccess

  type alias AuthorizationResult =
      AuthorizationResultWith AuthorizationError AuthorizationSuccess

  type AuthorizationResultWith error success
      = Empty
      | Error error
      | Success success
  ```

  ```elm
  -- type alias Parsers =
  --     { codeParser :
  --           Query.Parser (Maybe String)
  --     , errorParser :
  --           Query.Parser (Maybe ErrorCode)
  --     , authorizationSuccessParser :
  --           String -> Query.Parser AuthorizationSuccess
  --     , authorizationErrorParser :
  --           ErrorCode -> Query.Parser AuthorizationError
  --     }

  type alias Parsers error success =
      { codeParser :
            Query.Parser (Maybe String)
      , errorParser :
            Query.Parser (Maybe ErrorCode)
      , authorizationSuccessParser :
            String -> Query.Parser success
      , authorizationErrorParser :
            ErrorCode -> Query.Parser error
      }
  ```

  ```elm
  -- defaultParsers : Parsers
  defaultParsers : Parsers AuthorizationError AuthorizationSuccess
  ```

  ```elm
  -- parseCodeWith : Parsers -> Url -> AuthorizationResult
  parseCodeWith : Parsers error success -> Url -> AuthorizationResultWith error success
  ```

#### `OAuth.AuthorizationCode.PKCE` - MAJOR 

- Added:

  ```elm
  makeAuthorizationUrlWith :
      ResponseType
      -> Dict String String
      -> Authorization
      -> Url
  ```

  ```elm
  makeTokenRequestWith :
      OAuth.GrantType
      -> Json.Decoder success
      -> Dict String String
      -> (Result Http.Error success -> msg)
      -> Authentication
      -> RequestParts msg
  ```

- Changed:

  ```elm
  -- type AuthorizationResult
  --     = Empty
  --     | Error AuthorizationError
  --     | Success AuthorizationSuccess

  type alias AuthorizationResult =
      AuthorizationResultWith AuthorizationError AuthorizationSuccess

  type AuthorizationResultWith error success
      = Empty
      | Error error
      | Success success
  ```

  ```elm
  -- type alias Parsers =
  --     { codeParser :
  --           Query.Parser (Maybe String)
  --     , errorParser :
  --           Query.Parser (Maybe ErrorCode)
  --     , authorizationSuccessParser :
  --           String -> Query.Parser AuthorizationSuccess
  --     , authorizationErrorParser :
  --           ErrorCode -> Query.Parser AuthorizationError
  --     }

  type alias Parsers error success =
      { codeParser :
            Query.Parser (Maybe String)
      , errorParser :
            Query.Parser (Maybe ErrorCode)
      , authorizationSuccessParser :
            String -> Query.Parser success
      , authorizationErrorParser :
            ErrorCode -> Query.Parser error
      }
  ```

  ```elm
  -- defaultParsers : Parsers
  defaultParsers : Parsers AuthorizationError AuthorizationSuccess
  ```

  ```elm
  -- parseCodeWith : Parsers -> Url -> AuthorizationResult
  parseCodeWith : Parsers error success -> Url -> AuthorizationResultWith error success
  ```


#### `OAuth.ClientCredentials` - MINOR 

- Added:

  ```elm
  makeTokenRequestWith :
      GrantType
      -> Json.Decoder success
      -> Dict String String
      -> (Result Http.Error success -> msg)
      -> Authentication
      -> RequestParts msg
  ```

#### `OAuth.Password` - MINOR 

- Added:

  ```elm
  makeTokenRequestWith :
      GrantType
      -> Json.Decoder success
      -> Dict String String
      -> (Result Http.Error success -> msg)
      -> Authentication
      -> RequestParts msg
  ```


#### `OAuth.Refresh` - MINOR 

- Added:

  ```elm
  makeTokenRequestWith :
      GrantType
      -> Json.Decoder success
      -> Dict String String
      -> (Result Http.Error success -> msg)
      -> Authentication
      -> RequestParts msg
  ```